### PR TITLE
Set the js file in main, not spm.main

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "gulp-bower": "0.0.1",
         "gulp-wrap-umd": "*"
     },
+    "main": "shepherd.js",
     "spm": {
         "main": "shepherd.js"
     }


### PR DESCRIPTION
I'm installing shephard with npm by listing shepherd as a dependency:
`"shepherd": "git://github.com/HubSpot/shepherd.git#58a37fa0263bf205fff7a64abb62216b1738e0c2"`

To play nicely with Webpack (and probably Browserify) the the javascript file should be stored in the `main` property. `spm.main` would only work if I were using `spm`, which I'm not.

I don't want to break the `spm` support, so I've simply added the `main` property to the `package.json`
